### PR TITLE
Commenting out confirmation banner

### DIFF
--- a/app/views/includes/confirmation-banner.html
+++ b/app/views/includes/confirmation-banner.html
@@ -1,6 +1,8 @@
+<!–– commenting out this confirmation banner as it only appears at the start of a new session, which is confusing in testing
 <div class="confirmation-banner">
     <div class="confirmation-banner-tick">
         <img src="/public/images/confirmation-banner-tick-icon.png">
     </div>
     <div class="confirmation-banner-text">Your changes have been saved</div>
 </div>
+––>


### PR DESCRIPTION
Commenting out this confirmation banner as it only appears at the start of a new session, which is confusing in testing